### PR TITLE
framing: Fix parsing incoming messages

### DIFF
--- a/lib/blue_heron_transport_uart/framing.ex
+++ b/lib/blue_heron_transport_uart/framing.ex
@@ -5,65 +5,36 @@ defmodule BlueHeronTransportUART.Framing do
   Reference: Version 5.0, Vol 2, Part E, 5.4
   """
 
-  alias Circuits.UART.Framing
+  @behaviour Circuits.UART.Framing
 
-  defmodule State do
-    @moduledoc false
+  def init(_args), do: {:ok, <<>>}
 
-    defstruct frame: <<>>, remaining_bytes: nil, type: nil
+  def add_framing(data, rx_buffer) when is_binary(data) do
+    {:ok, data, rx_buffer}
   end
 
-  @behaviour Framing
+  def frame_timeout(rx_buffer), do: {:ok, [rx_buffer], <<>>}
+  def flush(:transmit, rx_buffer), do: rx_buffer
+  def flush(:receive, _rx_buffer), do: <<>>
+  def flush(:both, _rx_buffer), do: <<>>
 
-  @impl Framing
-  def init(_args), do: {:ok, %State{}}
+  def remove_framing(data, rx_buffer), do: process_data(rx_buffer <> data, [])
 
-  @impl Framing
-  def add_framing(data, state), do: {:ok, data, state}
-
-  @impl Framing
-  def flush(:transmit, state), do: state
-
-  def flush(:receive, _state), do: %State{}
-
-  def flush(:both, _state), do: %State{}
-
-  @impl Framing
-  def frame_timeout(state), do: {:ok, [state], <<>>}
-
-  @impl Framing
-  def remove_framing(new_data, state) do
-    process(state.frame <> new_data, %{state | frame: <<>>})
+  defp process_data(<<0x02, header::little-16, length::little-16, data::binary-size(length), rest::binary>>, messages) do
+    message = <<0x02, header::little-16, length::little-16, data::binary-size(length)>>
+    process_data(rest, messages ++ [message])
   end
 
-  def process(<<0x2, rest::binary>>, %{type: nil} = state) do
-    process(rest, %{state | type: 0x2})
+  defp process_data(<<0x04, event_code::size(8), length::size(8), event_parameters::binary-size(length), rest::binary>>, messages) do
+    message = <<0x04, event_code::size(8), length::size(8), event_parameters::binary-size(length)>>
+    process_data(rest, messages ++ [message])
   end
 
-  def process(<<0x4, rest::binary>>, %{type: nil} = state) do
-    process(rest, %{state | type: 0x4})
+  defp process_data(<<>>, messages) do
+    {:ok, messages, <<>>}
   end
 
-  def process(
-        <<handle::little-12, flags::4, length::little-16, data::binary-size(length),
-          rest::binary>>,
-        %{type: 0x2} = state
-      ) do
-    {:ok, [<<0x2, handle::little-12, flags::4, length::little-16, data::binary-size(length)>>],
-     %{state | type: nil, frame: rest}}
+  defp process_data(partial, messages) do
+    {:in_frame, messages, partial}
   end
-
-  def process(
-        <<event_code::size(8), parameter_total_length::size(8),
-          event_parameters::binary-size(parameter_total_length), rest::binary>>,
-        %{type: 0x4} = state
-      ) do
-    {:ok,
-     [
-       <<0x4, event_code::size(8), parameter_total_length::size(8),
-         event_parameters::binary-size(parameter_total_length)>>
-     ], %{state | type: nil, frame: rest}}
-  end
-
-  def process(data, state), do: {:in_frame, [], %{state | frame: data}}
 end


### PR DESCRIPTION
This change fixes an issue where messages were dropped during the framing process. If the RX buffer was holding more then one frame, the second frame was dropped causing the communication with the controller to stall.

The new framing module is based on the 4 byte implementation in `elixir-circuits/circuits_uart`.